### PR TITLE
examples/bus3dでバスの運行データをreadmeのjsonその１の方法で読み込む時のバグ修正

### DIFF
--- a/examples/bus3d/sagas/index.ts
+++ b/examples/bus3d/sagas/index.ts
@@ -113,7 +113,7 @@ function* fetchDataByAnswer({ answer }: { answer: string }) {
       const { segments, color: colorSpec } = trip;
       const operation: Bus3dMovesbaseOperation[] = [];
       segments.forEach((tripsegment, idx) => {
-        const [longitude, latitude, elapsedtime] = tripsegment;
+        const [elapsedtime, longitude, latitude] = tripsegment;
         const color = (colorSpec && colorSpec[idx]) ? colorSpec[idx] : COLOR1;
         operation.push({ elapsedtime, longitude, latitude, color });
         if (!(idx < (segments.length - 1) && (segments[(idx+1)|0][2] - tripsegment[2]) <= 10)) {


### PR DESCRIPTION
Harmoware-Visを研究で使わせていただいている大学院生です。
サンプルのbus3dをjson形式のバス運行データを用いて実行しようとした時にバグらしきものを見つけたので修正しました。

readmeが正しいのかコードが正しいのかはわかりませんでしたが、時間が最初にあった方がわかりやすいと思ってコードの方を修正いたしました。ご確認のほどよろしくお願いいたします。